### PR TITLE
Rename imports to use local version to make importable

### DIFF
--- a/cmd/tools/main.go
+++ b/cmd/tools/main.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/docker/go-tuf"
-	"github.com/docker/go-tuf/Godeps/_workspace/src/github.com/flynn/go-docopt"
-	"github.com/docker/go-tuf/store"
-	"github.com/docker/go-tuf/util"
+	"github.com/endophage/go-tuf"
+	"github.com/endophage/go-tuf/Godeps/_workspace/src/github.com/flynn/go-docopt"
+	"github.com/endophage/go-tuf/store"
+	"github.com/endophage/go-tuf/util"
 )
 
 func main() {

--- a/cmd/tools/meta.go
+++ b/cmd/tools/meta.go
@@ -6,9 +6,9 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/docker/go-tuf"
-	"github.com/docker/go-tuf/Godeps/_workspace/src/github.com/flynn/go-docopt"
-	"github.com/docker/go-tuf/util"
+	"github.com/endophage/go-tuf"
+	"github.com/endophage/go-tuf/Godeps/_workspace/src/github.com/flynn/go-docopt"
+	"github.com/endophage/go-tuf/util"
 )
 
 func init() {

--- a/data/hex_bytes_test.go
+++ b/data/hex_bytes_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	. "github.com/docker/go-tuf/Godeps/_workspace/src/gopkg.in/check.v1"
+	. "github.com/endophage/go-tuf/Godeps/_workspace/src/gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.

--- a/data/types.go
+++ b/data/types.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/docker/go-tuf/Godeps/_workspace/src/github.com/tent/canonical-json-go"
+	"github.com/endophage/go-tuf/Godeps/_workspace/src/github.com/tent/canonical-json-go"
 )
 
 const KeyIDLength = sha256.Size * 2

--- a/keys/db.go
+++ b/keys/db.go
@@ -4,8 +4,8 @@ import (
 	"crypto/rand"
 	"errors"
 
-	"github.com/docker/go-tuf/Godeps/_workspace/src/github.com/agl/ed25519"
-	"github.com/docker/go-tuf/data"
+	"github.com/endophage/go-tuf/Godeps/_workspace/src/github.com/agl/ed25519"
+	"github.com/endophage/go-tuf/data"
 )
 
 var (

--- a/repo.go
+++ b/repo.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/go-tuf/data"
-	"github.com/docker/go-tuf/keys"
-	"github.com/docker/go-tuf/signed"
-	"github.com/docker/go-tuf/store"
-	"github.com/docker/go-tuf/util"
+	"github.com/endophage/go-tuf/data"
+	"github.com/endophage/go-tuf/keys"
+	"github.com/endophage/go-tuf/signed"
+	"github.com/endophage/go-tuf/store"
+	"github.com/endophage/go-tuf/util"
 )
 
 type CompressionType uint8

--- a/repo_test.go
+++ b/repo_test.go
@@ -10,14 +10,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/go-tuf/Godeps/_workspace/src/github.com/agl/ed25519"
-	. "github.com/docker/go-tuf/Godeps/_workspace/src/gopkg.in/check.v1"
-	"github.com/docker/go-tuf/data"
-	"github.com/docker/go-tuf/store"
-	//	"github.com/docker/go-tuf/encrypted"
-	"github.com/docker/go-tuf/keys"
-	"github.com/docker/go-tuf/signed"
-	"github.com/docker/go-tuf/util"
+	"github.com/endophage/go-tuf/Godeps/_workspace/src/github.com/agl/ed25519"
+	. "github.com/endophage/go-tuf/Godeps/_workspace/src/gopkg.in/check.v1"
+	"github.com/endophage/go-tuf/data"
+	"github.com/endophage/go-tuf/store"
+	//	"github.com/endophage/go-tuf/encrypted"
+	"github.com/endophage/go-tuf/keys"
+	"github.com/endophage/go-tuf/signed"
+	"github.com/endophage/go-tuf/util"
 )
 
 // Hook up gocheck into the "go test" runner.

--- a/signed/interface.go
+++ b/signed/interface.go
@@ -1,8 +1,8 @@
 package signed
 
 import (
-	"github.com/docker/go-tuf/data"
-	"github.com/docker/go-tuf/keys"
+	"github.com/endophage/go-tuf/data"
+	"github.com/endophage/go-tuf/keys"
 )
 
 type Signer interface {

--- a/signed/sign.go
+++ b/signed/sign.go
@@ -1,9 +1,9 @@
 package signed
 
 import (
-	"github.com/docker/go-tuf/Godeps/_workspace/src/github.com/agl/ed25519"
-	cjson "github.com/docker/go-tuf/Godeps/_workspace/src/github.com/tent/canonical-json-go"
-	"github.com/docker/go-tuf/data"
+	"github.com/endophage/go-tuf/Godeps/_workspace/src/github.com/agl/ed25519"
+	cjson "github.com/endophage/go-tuf/Godeps/_workspace/src/github.com/tent/canonical-json-go"
+	"github.com/endophage/go-tuf/data"
 )
 
 // Sign takes a data.Signed and a key, calculated and adds the signature

--- a/signed/verify.go
+++ b/signed/verify.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/go-tuf/Godeps/_workspace/src/github.com/agl/ed25519"
-	"github.com/docker/go-tuf/Godeps/_workspace/src/github.com/tent/canonical-json-go"
-	"github.com/docker/go-tuf/data"
-	"github.com/docker/go-tuf/keys"
+	"github.com/endophage/go-tuf/Godeps/_workspace/src/github.com/agl/ed25519"
+	"github.com/endophage/go-tuf/Godeps/_workspace/src/github.com/tent/canonical-json-go"
+	"github.com/endophage/go-tuf/data"
+	"github.com/endophage/go-tuf/keys"
 )
 
 var (

--- a/signed/verify_test.go
+++ b/signed/verify_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/go-tuf/Godeps/_workspace/src/github.com/agl/ed25519"
-	"github.com/docker/go-tuf/data"
-	"github.com/docker/go-tuf/keys"
+	"github.com/endophage/go-tuf/Godeps/_workspace/src/github.com/agl/ed25519"
+	"github.com/endophage/go-tuf/data"
+	"github.com/endophage/go-tuf/keys"
 
-	. "github.com/docker/go-tuf/Godeps/_workspace/src/gopkg.in/check.v1"
+	. "github.com/endophage/go-tuf/Godeps/_workspace/src/gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.

--- a/store/dbstore.go
+++ b/store/dbstore.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 
 	"code.google.com/p/go-sqlite/go1/sqlite3"
-	"github.com/docker/go-tuf/data"
-	"github.com/docker/go-tuf/util"
+	"github.com/endophage/go-tuf/data"
+	"github.com/endophage/go-tuf/util"
 )
 
 const (

--- a/store/dbstore_test.go
+++ b/store/dbstore_test.go
@@ -4,8 +4,8 @@ import (
 	//	"fmt"
 	"testing"
 
-	"github.com/docker/go-tuf/data"
-	"github.com/docker/go-tuf/util"
+	"github.com/endophage/go-tuf/data"
+	"github.com/endophage/go-tuf/util"
 )
 
 // TestDBStore just ensures we can initialize an empty store.

--- a/store/interfaces.go
+++ b/store/interfaces.go
@@ -3,7 +3,7 @@ package store
 import (
 	"encoding/json"
 
-	"github.com/docker/go-tuf/data"
+	"github.com/endophage/go-tuf/data"
 )
 
 type targetsWalkFunc func(path string, meta data.FileMeta) error

--- a/store/local_store.go.bkp
+++ b/store/local_store.go.bkp
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/docker/go-tuf/data"
-	"github.com/docker/go-tuf/encrypted"
-	"github.com/docker/go-tuf/util"
+	"github.com/endophage/go-tuf/data"
+	"github.com/endophage/go-tuf/encrypted"
+	"github.com/endophage/go-tuf/util"
 )
 
 func MemoryStore(meta map[string]json.RawMessage, files map[string][]byte) LocalStore {

--- a/util/testutils.go
+++ b/util/testutils.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"code.google.com/p/go-sqlite/go1/sqlite3"
-	"github.com/docker/go-tuf/data"
+	"github.com/endophage/go-tuf/data"
 )
 
 func SampleMeta() data.FileMeta {

--- a/util/util.go
+++ b/util/util.go
@@ -13,7 +13,7 @@ import (
 	gopath "path"
 	"path/filepath"
 
-	"github.com/docker/go-tuf/data"
+	"github.com/endophage/go-tuf/data"
 )
 
 var ErrWrongLength = errors.New("wrong length")

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -5,8 +5,8 @@ import (
 	"encoding/hex"
 	"testing"
 
-	. "github.com/docker/go-tuf/Godeps/_workspace/src/gopkg.in/check.v1"
-	"github.com/docker/go-tuf/data"
+	. "github.com/endophage/go-tuf/Godeps/_workspace/src/gopkg.in/check.v1"
+	"github.com/endophage/go-tuf/data"
 )
 
 // Hook up gocheck into the "go test" runner.


### PR DESCRIPTION
This will allow this package to be imported as "github.com/endophage/go-tuf"
